### PR TITLE
feat: add macOS notification + speech on Notification events

### DIFF
--- a/scripts/notification-done.sh
+++ b/scripts/notification-done.sh
@@ -1,11 +1,34 @@
 #!/usr/bin/env bash
-# Fires on Notification — NO-OP for now.
-# The OTEL listener is the authoritative source for state transitions.
-# Notification events fire mid-work (tool progress, subagent updates), so we
-# cannot assume they mean "idle." Let the HoldTimer manage idle detection.
+# Fires on Notification — display macOS notification + speech announcement.
+# Receives JSON on stdin with message, title, session_id, etc.
+# Runs in detached context (no TTY) — uses osascript and say.
 set -u
 
-# This hook is now a no-op. The OTEL listener handles all state transitions.
-# Keeping it in hooks.json for potential future use (e.g., filtering specific
-# notification types), but for now it does nothing to avoid race conditions.
+_stdin="$(cat 2>/dev/null)" || true
+[ -z "$_stdin" ] && exit 0
+
+# Extract message and title from stdin JSON (no jq dependency)
+_msg="$(echo "$_stdin" | grep -o '"message":"[^"]*"' | head -1 | sed 's/"message":"//;s/"$//')" || true
+_title="$(echo "$_stdin" | grep -o '"title":"[^"]*"' | head -1 | sed 's/"title":"//;s/"$//')" || true
+
+# Fallback title
+[ -z "$_title" ] && _title="Claude Code"
+
+# Sanitize for osascript (escape double quotes)
+_msg_clean="$(echo "$_msg" | sed 's/"/\\"/g')" || true
+_title_clean="$(echo "$_title" | sed 's/"/\\"/g')" || true
+
+# 1. macOS notification (visual)
+if [ -n "$_msg_clean" ]; then
+  osascript -e "display notification \"${_msg_clean}\" with title \"${_title_clean}\"" 2>/dev/null || true
+fi
+
+# 2. Speech announcement (audio — harder to miss)
+# Truncate long messages and speak in background to avoid blocking
+if [ -n "$_msg" ]; then
+  # Truncate to ~200 chars for speech (keep it brief)
+  _speech="$(echo "$_msg" | cut -c1-200)" || true
+  say "$_speech" 2>/dev/null &
+fi
+
 exit 0


### PR DESCRIPTION
## Summary
- Display visual macOS notification via `osascript` on Notification events
- Speak the message via `say` so users don't miss important events
- Speech runs in background to avoid blocking the hook
- Parses message/title from stdin JSON (no jq dependency)

## Test plan
- [x] Verified locally with test stdin JSON — notification and speech fired
- [ ] Confirm on fresh install (no external deps)