### PR TITLE
fix: proceed hooks effectiveness — infinite-loop guard, staleness, instrumentation

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -65,6 +65,16 @@
             "type": "command",
             "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/teammate-proceed.sh",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/anti-stall.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/subagent-stop-validator.sh",
+            "timeout": 10
           }
         ]
       }

--- a/scripts/anti-stall.sh
+++ b/scripts/anti-stall.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
-# Anti-stall prompt hook: detects "planning without executing" pattern
-# Fires on SubagentStop — checks if subagent produced tool output
-# If subagent only planned but didn't execute, forces continuation
+# Anti-stall hook: detects "planning without executing" pattern
+# Fires on SubagentStop and TeammateIdle — checks if agent produced tool output
+# If agent only planned but didn't execute, forces continuation
 set -u
 
-SESSION_KEY="${GHOSTTY_OTEL_SESSION_KEY:-}"
+# Read stdin for stop_hook_active guard (infinite-loop prevention)
+INPUT="$(cat)"
+
+if echo "$INPUT" | command jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+    echo '{"ok":true}'
+    exit 0
+fi
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 STATE_DIR="${GHOSTTY_OTEL_STATE_DIR:-/tmp}"
+
+SESSION_INFO="$(bash "${PLUGIN_ROOT}/scripts/session-key.sh")"
+SESSION_KEY="$(echo "$SESSION_INFO" | sed -n '2p')"
+
 STATE_FILE="${STATE_DIR}/ghostty-indicator-state-${SESSION_KEY}.txt"
 TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
 

--- a/scripts/main-agent-proceed.sh
+++ b/scripts/main-agent-proceed.sh
@@ -1,33 +1,6 @@
 #!/usr/bin/env bash
-# StopFailure hook: detects stale idle (main agent went idle mid-task)
-# and auto-proceeds via structured JSON output.
-# Input: JSON on stdin with session_id, reason, transcript_path, cwd
+# StopFailure hook: state-file busy check
+# Delegates to shared proceed-by-state.sh
 set -u
-
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-STATE_DIR="${GHOSTTY_OTEL_STATE_DIR:-/tmp}"
-
-SESSION_INFO="$(bash "${PLUGIN_ROOT}/scripts/session-key.sh")"
-SESSION_KEY="$(echo "$SESSION_INFO" | sed -n '2p')"
-
-# Fail-closed: if session-key.sh fails, block to prevent mid-task stop
-if [ -z "$SESSION_KEY" ]; then
-  echo '{"ok":false,"systemMessage":"proceed — session resolution failed, assuming busy"}'
-  exit 0
-fi
-
-STATE_FILE="${STATE_DIR}/ghostty-indicator-state-${SESSION_KEY}.txt"
-
-current=""
-if [ -f "$STATE_FILE" ]; then
-  current=$(cat "$STATE_FILE" 2>/dev/null | tr -d '\n' | cut -d: -f1)
-fi
-
-case "$current" in
-  calling_llm|tool_running|tool_exec|subagent_idle|looping|waiting_input)
-    # Main agent stopped while still busy, or already detected as stale
-    echo '{"ok":false,"systemMessage":"proceed — continue your previous task"}'
-    exit 0
-    ;;
-esac
-exit 0
+bash "${PLUGIN_ROOT}/scripts/proceed-by-state.sh"

--- a/scripts/proceed-by-state.sh
+++ b/scripts/proceed-by-state.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Shared proceed-by-state logic for SubagentStop/TeammateIdle/StopFailure hooks
+# Detects stale idle (agent went idle mid-task) and auto-proceeds via structured JSON output.
+set -u
+
+# Read stdin for stop_hook_active guard (infinite-loop prevention)
+INPUT="$(cat)"
+
+# Guard against infinite loops — if stop_hook_active is true, allow the stop
+if echo "$INPUT" | command jq -e '.stop_hook_active == true' >/dev/null 2>&1; then
+    echo '{"ok":true}'
+    exit 0
+fi
+
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+STATE_DIR="${GHOSTTY_OTEL_STATE_DIR:-/tmp}"
+HOLD_SECONDS="${GHOSTTY_OTEL_HOLD_SECONDS:-60}"
+
+SESSION_INFO="$(bash "${PLUGIN_ROOT}/scripts/session-key.sh")"
+SESSION_KEY="$(echo "$SESSION_INFO" | sed -n '2p')"
+
+# Fail-closed: if session-key.sh fails, block to prevent mid-task stop
+# The stop_hook_active guard above prevents infinite loops from this case
+if [ -z "$SESSION_KEY" ]; then
+    echo '{"ok":false,"systemMessage":"proceed — session resolution failed, assuming busy"}'
+    exit 0
+fi
+
+STATE_FILE="${STATE_DIR}/ghostty-indicator-state-${SESSION_KEY}.txt"
+
+current=""
+if [ -f "$STATE_FILE" ]; then
+    current=$(cat "$STATE_FILE" 2>/dev/null | tr -d '\n' | cut -d: -f1)
+fi
+
+# Staleness check: if state file hasn't been updated in > HOLD_SECONDS+5,
+# the state is likely stale (HoldTimer expired but listener didn't write idle)
+# Allow the stop in this case to prevent false-positive proceeds
+if [ -n "$current" ] && [ "$current" != "idle" ]; then
+    STATE_MTIME=$(stat -f '%m' "$STATE_FILE" 2>/dev/null || stat -c '%Y' "$STATE_FILE" 2>/dev/null || echo "0")
+    CURRENT_TIME=$(date +%s)
+    STATE_AGE=$((CURRENT_TIME - STATE_MTIME))
+    if [ "$STATE_AGE" -ge "$((HOLD_SECONDS + 5))" ]; then
+        echo '{"ok":true}'
+        exit 0
+    fi
+fi
+
+case "$current" in
+  calling_llm|tool_running|tool_exec|subagent_idle|looping)
+    # Agent stopped while still busy, or already detected as stale
+    echo '{"ok":false,"systemMessage":"proceed — continue your previous task"}'
+    exit 0
+    ;;
+esac
+
+echo '{"ok":true}'
+exit 0

--- a/scripts/subagent-proceed.sh
+++ b/scripts/subagent-proceed.sh
@@ -1,33 +1,6 @@
 #!/usr/bin/env bash
-# SubagentStop hook: detects stale idle (subagent went idle mid-task)
-# and auto-proceeds via structured JSON output.
-# Input: JSON on stdin with last_assistant_message, agent_id, agent_type
+# SubagentStop hook: state-file busy check
+# Delegates to shared proceed-by-state.sh
 set -u
-
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-STATE_DIR="${GHOSTTY_OTEL_STATE_DIR:-/tmp}"
-
-SESSION_INFO="$(bash "${PLUGIN_ROOT}/scripts/session-key.sh")"
-SESSION_KEY="$(echo "$SESSION_INFO" | sed -n '2p')"
-
-# Fail-closed: if session-key.sh fails, block to prevent mid-task stop
-if [ -z "$SESSION_KEY" ]; then
-  echo '{"ok":false,"systemMessage":"proceed — session resolution failed, assuming busy"}'
-  exit 0
-fi
-
-STATE_FILE="${STATE_DIR}/ghostty-indicator-state-${SESSION_KEY}.txt"
-
-current=""
-if [ -f "$STATE_FILE" ]; then
-  current=$(cat "$STATE_FILE" 2>/dev/null | tr -d '\n' | cut -d: -f1)
-fi
-
-case "$current" in
-  calling_llm|tool_running|tool_exec|subagent_idle|looping|waiting_input)
-    # Subagent stopped while still busy, or already detected as stale
-    echo '{"ok":false,"systemMessage":"proceed — continue your previous task"}'
-    exit 0
-    ;;
-esac
-exit 0
+bash "${PLUGIN_ROOT}/scripts/proceed-by-state.sh"

--- a/scripts/subagent-stop-validator.sh
+++ b/scripts/subagent-stop-validator.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Subagent stop validator - command hook replacement for prompt-based SubagentStop hook
-# Same logic as stop-validator.sh but with subagent-specific messaging
-
+# Stop validator for SubagentStop and TeammateIdle hooks
+# Checks transcript for real tool usage and unresolved errors
 set -euo pipefail
 
 INPUT="$(cat)"
@@ -45,12 +44,12 @@ else
 fi
 
 if [[ "$HAS_REAL_TOOLS" -eq 0 ]]; then
-    echo '{"ok":false,"systemMessage":"Subagent stopped without executing any real tools — continuing task"}'
+    echo '{"ok":false,"systemMessage":"Agent stopped without executing any real tools — continuing task"}'
     exit 0
 fi
 
 if [[ "$HAS_ERRORS" -gt 0 ]]; then
-    echo '{"ok":false,"systemMessage":"Subagent had tool errors — continuing to resolve"}'
+    echo '{"ok":false,"systemMessage":"Agent had tool errors — continuing to resolve"}'
     exit 0
 fi
 

--- a/scripts/teammate-proceed.sh
+++ b/scripts/teammate-proceed.sh
@@ -1,33 +1,6 @@
 #!/usr/bin/env bash
-# TeammateIdle hook: detects stale idle (teammate went idle mid-task)
-# and auto-proceeds via structured JSON output.
-# Input: JSON on stdin with last_assistant_message, agent_id, agent_type
+# TeammateIdle hook: state-file busy check
+# Delegates to shared proceed-by-state.sh
 set -u
-
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
-STATE_DIR="${GHOSTTY_OTEL_STATE_DIR:-/tmp}"
-
-SESSION_INFO="$(bash "${PLUGIN_ROOT}/scripts/session-key.sh")"
-SESSION_KEY="$(echo "$SESSION_INFO" | sed -n '2p')"
-
-# Fail-closed: if session-key.sh fails, block to prevent mid-task stop
-if [ -z "$SESSION_KEY" ]; then
-  echo '{"ok":false,"systemMessage":"proceed — session resolution failed, assuming busy"}'
-  exit 0
-fi
-
-STATE_FILE="${STATE_DIR}/ghostty-indicator-state-${SESSION_KEY}.txt"
-
-current=""
-if [ -f "$STATE_FILE" ]; then
-  current=$(cat "$STATE_FILE" 2>/dev/null | tr -d '\n' | cut -d: -f1)
-fi
-
-case "$current" in
-  calling_llm|tool_running|tool_exec|subagent_idle|looping|waiting_input)
-    # Teammate stopped while still busy, or already detected as stale
-    echo '{"ok":false,"systemMessage":"proceed — continue your previous task"}'
-    exit 0
-    ;;
-esac
-exit 0
+bash "${PLUGIN_ROOT}/scripts/proceed-by-state.sh"


### PR DESCRIPTION
## Summary

Fixes #3 — all 7 issues from the effectiveness review:

- **Infinite-loop guard** — added `stop_hook_active` check to all proceed scripts (was only in `subagent-stop-validator.sh`)
- **DRY violation** — extracted shared `proceed-by-state.sh`; all 3 proceed scripts are now 6-line thin wrappers
- **anti-stall.sh session key bug** — switched from `GHOSTTY_OTEL_SESSION_KEY` env var (unavailable in subagents) to `session-key.sh`
- **State staleness** — added mtime check (>HOLD_SECONDS+5) to `proceed-by-state.sh`; stale busy states now allow stop
- **`waiting_input` removal** — no longer treated as busy state in proceed scripts (handled by `state-proceed.sh` with 90s threshold)
- **TeammateIdle instrumentation** — now has same 3-hook chain as SubagentStop (proceed + anti-stall + transcript validation)
- **Generic messages** — `subagent-stop-validator.sh` uses "Agent" instead of "Subagent" for reuse

## Files changed

| File | Change |
|------|--------|
| `scripts/proceed-by-state.sh` | **NEW** — shared proceed logic with guard + staleness |
| `scripts/subagent-proceed.sh` | 34 → 6 lines — thin wrapper |
| `scripts/teammate-proceed.sh` | 34 → 6 lines — thin wrapper |
| `scripts/main-agent-proceed.sh` | 34 → 6 lines — thin wrapper |
| `scripts/anti-stall.sh` | Fixed session key + added guard |
| `scripts/subagent-stop-validator.sh` | Generic messages |
| `hooks/hooks.json` | TeammateIdle: 1 → 3 hooks |

## Effectiveness matrix (after)

| Aspect | SubagentStop | TeammateIdle |
|--------|-------------|-------------|
| State-file check | ✅ | ✅ |
| Anti-stall detection | ✅ | ✅ |
| Transcript validation | ✅ | ✅ |
| Infinite-loop guard | ✅ | ✅ |
| State staleness handling | ✅ | ✅ |

## Test plan

- [x] `python3 -c "import json; json.load(open('hooks/hooks.json'))"` — hooks.json valid
- [x] `bash -n` — all modified scripts have valid syntax
- [x] `waiting_input` not in `proceed-by-state.sh` busy states
- [ ] Manual: verify subagent stop works with state file showing busy
- [ ] Manual: verify subagent stop works with stale state file (>60s)
- [ ] Manual: verify teammate idle triggers anti-stall + transcript checks
- [ ] Manual: verify no infinite loop when session-key.sh fails