### PR TITLE
feat: add npm installer and status command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__/
 .venv/
 venv/
 
+# Node
+node_modules/
+
 # Claude Code temp files
 .orphaned_at
 scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -45,38 +45,44 @@ Claude Code can run for minutes on complex tasks — calling LLMs, executing too
 
 - [Ghostty](https://ghostty.org) terminal
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) CLI
+- Node.js 18+ (for the installer)
+- Python 3 (for the OTEL listener)
 
-### Install
-
-1. Add the plugin to your Claude Code marketplace sources:
+### Install (one command)
 
 ```bash
-# Create marketplace directory
-mkdir -p ~/claude-marketplaces/kianwoon
-
-# Clone the plugin
-git clone https://github.com/kianwoon/ghostty-otel.git ~/claude-marketplaces/kianwoon/ghostty-otel
+npx ghostty-otel
 ```
 
-2. Register the marketplace in your Claude Code settings (`~/.claude/settings.json`):
+This automatically:
+1. Checks prerequisites (Claude Code, Node.js, Python 3)
+2. Registers the plugin marketplace in `~/.claude/settings.json`
+3. Enables the plugin
+4. Verifies the installation
+
+### Install (manual)
+
+If you prefer manual setup, add to `~/.claude/settings.json`:
 
 ```json
 {
-  "marketplace": [
-    { "uri": "~/claude-marketplaces/kianwoon" }
-  ]
+  "extraKnownMarketplaces": {
+    "kianwoon": {
+      "source": { "source": "github", "repo": "kianwoon/ghostty-otel" }
+    }
+  }
 }
 ```
 
-3. Install the plugin:
-
-```bash
-claude install-plugin ghostty-otel
-```
-
-4. Restart Claude Code. The plugin activates automatically on session start.
+Then inside Claude Code, run `/plugin` to install `ghostty-otel@kianwoon`.
 
 ### Verify
+
+```bash
+npx ghostty-otel status
+```
+
+Or manually:
 
 ```bash
 # Check the listener is running

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+var command = (process.argv[2] || 'install').toLowerCase();
+
+if (command === 'status') {
+  require('./status.js');
+} else if (command === 'install') {
+  require('./install.js');
+} else {
+  console.log('ghostty-otel — Real-time Claude Code visibility for Ghostty\n');
+  console.log('Usage: npx ghostty-otel [command]\n');
+  console.log('Commands:');
+  console.log('  install   Install the plugin (default)');
+  console.log('  status    Check plugin health and status');
+  console.log('\nOptions:');
+  console.log('  -h, --help   Show this help');
+  process.exit(0);
+}

--- a/bin/install.js
+++ b/bin/install.js
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+
+var cp = require('child_process');
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+
+var HOME = os.homedir();
+var SETTINGS_PATH = path.join(HOME, '.claude', 'settings.json');
+var MARKETPLACE_NAME = 'kianwoon';
+var MARKETPLACE_REPO = 'kianwoon/ghostty-otel';
+var PLUGIN_NAME = 'ghostty-otel';
+
+// ── Helpers ──────────────────────────────────────────────────
+function log(msg) { console.log(msg); }
+function ok(msg) { console.log('  ✓ ' + msg); }
+function warn(msg) { console.log('  ⚠ ' + msg); }
+function fail(msg) { console.log('  ✗ ' + msg); }
+
+function execSafe(cmd) {
+  try { return cp.execSync(cmd, { encoding: 'utf8', timeout: 10000 }).trim(); }
+  catch (_) { return null; }
+}
+
+// ── Step 1: Prerequisites ────────────────────────────────────
+log('\nghostty-otel installer\n');
+log('Checking prerequisites...');
+
+var hasClaude = execSafe('which claude') !== null;
+var hasNode = execSafe('which node') !== null;
+var hasPython3 = execSafe('which python3') !== null;
+
+if (hasClaude) ok('Claude Code CLI found');
+else { fail('Claude Code CLI not found — install from https://docs.anthropic.com/en/docs/claude-code'); }
+
+if (hasNode) ok('Node.js found');
+else fail('Node.js not found');
+
+if (hasPython3) ok('Python 3 found');
+else warn('Python 3 not found — OTEL listener requires Python 3');
+
+if (!hasClaude) {
+  console.log('\nInstall Claude Code first, then re-run: npx ghostty-otel');
+  process.exit(1);
+}
+
+// ── Step 2: Register marketplace ─────────────────────────────
+log('\nRegistering marketplace...');
+
+var settings = {};
+try {
+  settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+} catch (_) {
+  settings = {};
+}
+
+if (!settings.extraKnownMarketplaces) {
+  settings.extraKnownMarketplaces = {};
+}
+
+if (settings.extraKnownMarketplaces[MARKETPLACE_NAME]) {
+  ok('Marketplace "' + MARKETPLACE_NAME + '" already registered');
+} else {
+  settings.extraKnownMarketplaces[MARKETPLACE_NAME] = {
+    source: { source: 'github', repo: MARKETPLACE_REPO }
+  };
+  try {
+    fs.mkdirSync(path.dirname(SETTINGS_PATH), { recursive: true });
+    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+    ok('Marketplace "' + MARKETPLACE_NAME + '" registered in settings.json');
+  } catch (e) {
+    fail('Could not write settings.json: ' + e.message);
+    process.exit(1);
+  }
+}
+
+// ── Step 3: Enable plugin ────────────────────────────────────
+log('\nEnabling plugin...');
+
+if (!settings.enabledPlugins) {
+  settings.enabledPlugins = {};
+}
+
+var pluginId = PLUGIN_NAME + '@' + MARKETPLACE_NAME;
+if (settings.enabledPlugins[pluginId]) {
+  ok('Plugin already enabled');
+} else {
+  settings.enabledPlugins[pluginId] = true;
+  try {
+    fs.writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2));
+    ok('Plugin enabled in settings.json');
+  } catch (e) {
+    fail('Could not write settings.json: ' + e.message);
+  }
+}
+
+// ── Step 4: Verify ───────────────────────────────────────────
+log('\nVerifying installation...');
+
+var STATE_DIR = process.env.GHOSTTY_OTEL_STATE_DIR || '/tmp';
+var pidFile = path.join(STATE_DIR, 'ghostty-otel.pid');
+
+try {
+  var pid = fs.readFileSync(pidFile, 'utf8').trim();
+  process.kill(parseInt(pid), 0);
+  ok('OTEL listener running (PID ' + pid + ')');
+} catch (_) {
+  warn('OTEL listener not running yet — starts automatically on next Claude Code session');
+}
+
+var ttyPath = execSafe('tty 2>/dev/null');
+if (ttyPath && ttyPath !== 'not a tty') {
+  var sessionKey = path.basename(ttyPath).replace(/[^a-zA-Z0-9_-]/g, '');
+  var stateFile = path.join(STATE_DIR, 'ghostty-indicator-state-' + sessionKey + '.txt');
+  try {
+    var state = fs.readFileSync(stateFile, 'utf8').trim();
+    ok('Session key: ' + sessionKey + ' (state: ' + state + ')');
+  } catch (_) {
+    ok('Session key: ' + sessionKey + ' (state file created on first use)');
+  }
+}
+
+// ── Done ─────────────────────────────────────────────────────
+log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+log('ghostty-otel installed!\n');
+log('Next steps:');
+log('  1. Start a new Claude Code session (or restart)');
+log('  2. The indicator activates automatically');
+log('  3. Run "npx ghostty-otel status" to check health');
+log('');
+log('To install inside Claude Code, use: /plugin');
+log('');

--- a/bin/status.js
+++ b/bin/status.js
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var path = require('path');
+var os = require('os');
+var cp = require('child_process');
+
+var HOME = os.homedir();
+var STATE_DIR = process.env.GHOSTTY_OTEL_STATE_DIR || '/tmp';
+var SETTINGS_PATH = path.join(HOME, '.claude', 'settings.json');
+
+// ── Helpers ──────────────────────────────────────────────────
+function ok(msg) { return '  ✓ ' + msg; }
+function warn(msg) { return '  ⚠ ' + msg; }
+function fail(msg) { return '  ✗ ' + msg; }
+
+function execSafe(cmd) {
+  try { return cp.execFileSync('/bin/sh', ['-c', cmd], { encoding: 'utf8', timeout: 10000 }).trim(); }
+  catch (_) { return null; }
+}
+
+// ── Status checks ────────────────────────────────────────────
+var results = [];
+
+// 1. Plugin registered?
+var pluginRegistered = false;
+try {
+  var settings = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  var marketplace = (settings.extraKnownMarketplaces || {})['kianwoon'];
+  pluginRegistered = !!marketplace;
+  results.push(pluginRegistered
+    ? ok('Plugin marketplace registered')
+    : fail('Plugin marketplace NOT registered — run: npx ghostty-otel'));
+} catch (_) {
+  results.push(fail('Cannot read ~/.claude/settings.json'));
+}
+
+// 2. Plugin enabled?
+var pluginEnabled = false;
+try {
+  var settings2 = JSON.parse(fs.readFileSync(SETTINGS_PATH, 'utf8'));
+  pluginEnabled = settings2.enabledPlugins &&
+    settings2.enabledPlugins['ghostty-otel@kianwoon'] === true;
+  results.push(pluginEnabled
+    ? ok('Plugin enabled')
+    : warn('Plugin not enabled — run: npx ghostty-otel'));
+} catch (_) {}
+
+// 3. OTEL listener running?
+var listenerPid = null;
+try {
+  listenerPid = fs.readFileSync(path.join(STATE_DIR, 'ghostty-otel.pid'), 'utf8').trim();
+  process.kill(parseInt(listenerPid), 0);
+  results.push(ok('OTEL listener running (PID ' + listenerPid + ')'));
+} catch (_) {
+  if (listenerPid) {
+    results.push(fail('OTEL listener dead (stale PID ' + listenerPid + ')'));
+  } else {
+    results.push(warn('OTEL listener not running — starts on next Claude Code session'));
+  }
+}
+
+// 4. Watcher running?
+var ttyPath = execSafe('tty 2>/dev/null');
+if (ttyPath && ttyPath !== 'not a tty') {
+  var sessionKey = path.basename(ttyPath).replace(/[^a-zA-Z0-9_-]/g, '');
+  var watcherPidFile = path.join(STATE_DIR, 'ghostty-watcher-' + sessionKey + '.pid');
+  try {
+    var wpid = fs.readFileSync(watcherPidFile, 'utf8').trim();
+    process.kill(parseInt(wpid), 0);
+    results.push(ok('Watcher running (PID ' + wpid + ', session ' + sessionKey + ')'));
+  } catch (_) {
+    results.push(warn('Watcher not running for session ' + sessionKey));
+  }
+
+  // 5. State file
+  var stateFile = path.join(STATE_DIR, 'ghostty-indicator-state-' + sessionKey + '.txt');
+  try {
+    var state = fs.readFileSync(stateFile, 'utf8').trim();
+    results.push(ok('State: ' + state + ' (session ' + sessionKey + ')'));
+  } catch (_) {
+    results.push(warn('No state file yet for session ' + sessionKey));
+  }
+
+  // 6. SID mapping
+  var sidFiles = fs.readdirSync(STATE_DIR).filter(function(f) {
+    return f.indexOf('ghostty-sid-' + sessionKey) === 0;
+  });
+  results.push(sidFiles.length > 0
+    ? ok('SID mapping found (' + sidFiles.length + ' file' + (sidFiles.length > 1 ? 's' : '') + ')')
+    : warn('No SID mapping — created on first OTEL span'));
+} else {
+  results.push(warn('No TTY detected — session-specific checks skipped'));
+}
+
+// 7. Active sessions
+try {
+  var stateFiles = fs.readdirSync(STATE_DIR).filter(function(f) {
+    return f.indexOf('ghostty-indicator-state-') === 0 && f.endsWith('.txt');
+  });
+  if (stateFiles.length > 0) {
+    results.push(ok('Active sessions: ' + stateFiles.length));
+    stateFiles.forEach(function(f) {
+      var key = f.replace('ghostty-indicator-state-', '').replace('.txt', '');
+      try {
+        var s = fs.readFileSync(path.join(STATE_DIR, f), 'utf8').trim();
+        results.push('    ' + key + ': ' + s);
+      } catch (_) {}
+    });
+  }
+} catch (_) {}
+
+// ── Output ───────────────────────────────────────────────────
+console.log('\nghostty-otel status\n');
+results.forEach(function(r) { console.log(r); });
+
+var healthy = pluginRegistered && pluginEnabled && listenerPid;
+console.log('\n' + (healthy ? '✓ All systems healthy' : '⚠ Some issues detected — see above'));
+console.log('');

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "ghostty-otel",
+  "version": "1.15.0",
+  "description": "Real-time Claude Code agent visibility in Ghostty terminal — OTEL-powered progress indicators, anti-stall guards, and multi-session awareness",
+  "bin": {
+    "ghostty-otel": "./bin/cli.js"
+  },
+  "scripts": {
+    "postinstall": "node ./bin/install.js"
+  },
+  "files": [
+    "bin/",
+    "hooks/",
+    "scripts/",
+    ".claude-plugin/"
+  ],
+  "keywords": [
+    "claude-code",
+    "ghostty",
+    "opentelemetry",
+    "terminal",
+    "cli-plugin",
+    "productivity",
+    "otel",
+    "indicator"
+  ],
+  "author": "kianwoonwong",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kianwoon/ghostty-otel.git"
+  },
+  "homepage": "https://github.com/kianwoon/ghostty-otel#readme",
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}


### PR DESCRIPTION
## Summary

- **One-command install**: `npx ghostty-otel` — auto-registers marketplace, enables plugin, verifies installation
- **Status command**: `npx ghostty-otel status` — checks listener, watcher, state files, SID mappings, active sessions
- **Prerequisites check**: verifies Claude Code, Node.js, Python 3 before installing
- **package.json**: npm package config for distribution
- **Updated README**: Quick Start now shows `npx` one-liner as primary install method

## New files
- `package.json` — npm package manifest
- `bin/cli.js` — CLI entry point (install/status subcommands)
- `bin/install.js` — installer with prerequisites check and verification
- `bin/status.js` — health check command

## Test plan

- [x] `node bin/install.js` — passes on existing installation (idempotent)
- [x] `node bin/status.js` — shows 4 active sessions, listener healthy
- [ ] `npm publish --dry-run` — verify package contents
- [ ] Test on a fresh machine with `npx ghostty-otel`